### PR TITLE
fix(sitemap): include videos static page

### DIFF
--- a/lib/static-pages.test.mjs
+++ b/lib/static-pages.test.mjs
@@ -7,10 +7,15 @@ const modulePath = pathToFileURL(
   path.resolve(import.meta.dirname, "./static-pages.ts"),
 ).href;
 
-test("getStaticPageSitemapEntries includes the brands page", async () => {
+test("getStaticPageSitemapEntries includes public static pages", async () => {
   const { getStaticPageSitemapEntries } = await import(modulePath);
 
   const entries = getStaticPageSitemapEntries("https://example.com");
+  const urls = entries.map((entry) => entry.url);
+
+  assert.ok(urls.includes("https://example.com/about/"));
+  assert.ok(urls.includes("https://example.com/videos/"));
+  assert.ok(!urls.includes("https://example.com/projects/"));
 
   assert.ok(
     entries.some(

--- a/lib/static-pages.ts
+++ b/lib/static-pages.ts
@@ -26,10 +26,22 @@ export function getStaticPageSitemapEntries(baseUrl: string): MetadataRoute.Site
       priority: 0.8,
     },
     {
+      url: sitemapUrl(baseUrl, "/about/"),
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
       url: sitemapUrl(baseUrl, "/brands/"),
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.5,
+    },
+    {
+      url: sitemapUrl(baseUrl, "/videos/"),
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.6,
     },
     {
       url: sitemapUrl(baseUrl, "/tools/character-counter/"),


### PR DESCRIPTION
## Summary

- add `/about/` and `/videos/` to the XML sitemap static entries
- keep `/projects/` excluded after route removal
- expand the sitemap unit test to cover the public static routes

## Validation

- `node --test lib/static-pages.test.mjs`
- `npx tsc --noEmit --pretty false`
- `node --test app/home-hero.test.mjs lib/*.test.mjs components/*.test.mjs`
- `pnpm run build:cloudflare`